### PR TITLE
remove cube from docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,23 +62,6 @@ services:
     #env_file: ./.env
     environment:
       HOME: /home/node
-  cube:
-    container_name: cube
-    build:
-      context: ./cube
-      target: development
-    env_file: .env
-    depends_on:
-      - db
-    ports:
-      - "4000:4000"
-    volumes:
-      - ./cube/:/home/node/app/
-      - cube_nodemodules:/home/node/app/node_modules
-      - cube_extensions:/home/node/.vscode-server
-    command: npm run dev
-    links:
-      - redis_db
 volumes:
   frontend_nodemodules:
   frontend_extensions:


### PR DESCRIPTION
remove cube.js from docker setup.

 -> keeps the initial cube.js files as backup if we want to reimplement it later