### PR TITLE
Add `level=personal` to HeatingAggregated and ElectricityAggregated endpoints

### DIFF
--- a/backend/src/emissions/data/test_data.json
+++ b/backend/src/emissions/data/test_data.json
@@ -69,12 +69,22 @@
 
   }
 },
-"heatings": [
+"heating": [
   {
     "working_group_id": "2f681772-9fcd-11ed-a8fc-0242ac120002",
     "consumption": 2000,
     "unit": "l",
     "fuel_type": "oil",
+    "building": "348",
+    "timestamp": "2022-01-01",
+    "group_share": 1
+  }
+],
+"electricity": [
+  {
+    "working_group_id": "2f681772-9fcd-11ed-a8fc-0242ac120002",
+    "consumption": 1000,
+    "fuel_type": "german_energy_mix",
     "building": "348",
     "timestamp": "2022-01-01",
     "group_share": 1

--- a/backend/src/emissions/data/test_data.json
+++ b/backend/src/emissions/data/test_data.json
@@ -30,7 +30,7 @@
 },
 "institutions": {
   "institution1": {
-    "id": 1,
+    "id": "59812cd8-9fcd-11ed-a8fc-0242ac120002",
     "name": "Test University",
     "city": "Heidelberg",
     "country": "Germany"
@@ -38,10 +38,10 @@
 },
 "working_groups": {
   "working_group1": {
-    "id": 1,
+    "id": "2f681772-9fcd-11ed-a8fc-0242ac120002",
     "name": "testgroup1",
     "institution": {
-      "id": 1
+      "id": "59812cd8-9fcd-11ed-a8fc-0242ac120002"
     },
     "representative": "test3_rep",
     "n_employees": 10,
@@ -51,10 +51,10 @@
     "is_public": "True"
   },
     "working_group2": {
-      "id": 2,
+      "id": "3aaa81a6-9fcd-11ed-a8fc-0242ac120002",
       "name": "testgroup2",
       "institution": {
-        "id": 1
+        "id": "59812cd8-9fcd-11ed-a8fc-0242ac120002"
       },
       "representative": "test4_rep",
       "n_employees": 10,
@@ -68,5 +68,16 @@
   "business_trip1": {
 
   }
-}
+},
+"heatings": [
+  {
+    "working_group_id": "2f681772-9fcd-11ed-a8fc-0242ac120002",
+    "consumption": 2000,
+    "unit": "l",
+    "fuel_type": "oil",
+    "building": "348",
+    "timestamp": "2022-01-01",
+    "group_share": 1
+  }
+]
 }

--- a/backend/src/emissions/management/commands/create_test_data.py
+++ b/backend/src/emissions/management/commands/create_test_data.py
@@ -6,8 +6,11 @@ import json
 import logging
 import os
 from django.core.management.base import BaseCommand
+from django.core.exceptions import ValidationError
 from django.db.utils import IntegrityError
-from emissions.models import CustomUser, WorkingGroup, Institution, ResearchField
+from emissions.models import CustomUser, WorkingGroup, Institution, ResearchField, Heating
+
+from co2calculator.co2calculator import calc_co2_heating
 
 logger = logging.basicConfig()
 script_path = os.path.dirname(os.path.realpath(__file__))
@@ -69,7 +72,6 @@ class Command(BaseCommand):
             except Exception as e:
                 print(e)
 
-
         # Create institutions
         institutions = config_data["institutions"]
         for institution, institution_data in institutions.items():
@@ -107,11 +109,41 @@ class Command(BaseCommand):
                 representative_user.is_representative = True
                 representative_user.working_group = working_group
                 representative_user.save()
-
             except IntegrityError as e:
                 print(e)
+            except ValidationError as e:
+                print(e)
 
+        # Create heating entries
+        print("Loading heating entries...")
+        heating_entries = config_data["heatings"]
+        for data in heating_entries:
+            try:
+                working_group = WorkingGroup.objects.filter(id=data["working_group_id"])[0]
 
+                # Calculate co2e
+                co2e = calc_co2_heating(
+                    consumption=data["consumption"],
+                    unit=data["unit"],
+                    fuel_type=data["fuel_type"],
+                    area_share=data["group_share"],
+                )
+                co2e_cap = co2e / working_group.n_employees
+
+                # Store in database
+                new_heating = Heating(
+                    working_group=working_group,
+                    timestamp=data["timestamp"],
+                    consumption=data["consumption"],
+                    fuel_type=data["fuel_type"],
+                    building=data["building"],
+                    group_share=data["group_share"],
+                    co2e=co2e,
+                    co2e_cap=co2e_cap
+                )
+                new_heating.save()
+            except IntegrityError as e:
+                print(e)
 
         # Create business trips
         # business_trips = config_data["business_trips"]

--- a/backend/src/emissions/schema.py
+++ b/backend/src/emissions/schema.py
@@ -300,8 +300,11 @@ class Query(UserQuery, MeQuery, ObjectType):
         param: level: Aggregation level: personal, group or institution. Default: group
         param: time_interval: Aggregate co2e per "month" or "year"
         """
-        if not info.context.user.is_authenticated:
-            raise GraphQLError("User is not authenticated.")
+        #if not info.context.user.is_authenticated:
+        #    raise GraphQLError("User is not authenticated.")
+
+        if info.context.user.working_group is None:
+            raise GraphQLError("No heating data available, since user is not assigned to any working group yet.")
 
         # Get relevant data entries
         if level in ["group", "personal"]:

--- a/backend/src/emissions/schema.py
+++ b/backend/src/emissions/schema.py
@@ -296,17 +296,15 @@ class Query(UserQuery, MeQuery, ObjectType):
         self, info, level="group", time_interval="month", **kwargs
     ):
         """
-        Yields monthly co2e emissions (per capita) of heating consumption
-        - for a group (if group_id is given),
-        - for an institution (if inst_id is given)
-        param: level: Aggregation level: group or institution. Default: group
+        Yields monthly co2e emissions (per capita) of heating consumption, for the user, their group or their institution
+        param: level: Aggregation level: personal, group or institution. Default: group
         param: time_interval: Aggregate co2e per "month" or "year"
         """
         if not info.context.user.is_authenticated:
             raise GraphQLError("User is not authenticated.")
 
         # Get relevant data entries
-        if level == "group":
+        if level in ["group", "personal"]:
             entries = Heating.objects.filter(
                 working_group__id=info.context.user.working_group.id
             )

--- a/backend/src/emissions/schema.py
+++ b/backend/src/emissions/schema.py
@@ -342,15 +342,13 @@ class Query(UserQuery, MeQuery, ObjectType):
         self, info, level="group", time_interval="month", **kwargs
     ):
         """
-        Yields monthly co2e emissions of electricity consumption
-        - for a group (if group_id is given),
-        - for an institutions (if inst_id is given)
+        Yields monthly co2e emissions (per capita) of electricity consumption, for the user, their group or their institution
         param: level: Aggregation level: group or institution. Default: group
         param: time_interval: Aggregate co2e per "month" or "year"
         """
         user = info.context.user
         # Get relevant data entries
-        if level == "group":
+        if level in ["group", "personal"]:
             entries = Heating.objects.filter(working_group__id=user.working_group.id)
         elif level == "institution":
             entries = Heating.objects.filter(

--- a/backend/src/emissions/tests/test_query_data.py
+++ b/backend/src/emissions/tests/test_query_data.py
@@ -70,7 +70,7 @@ def test_query_heating_aggregated_personal(test_user3_rep_token):
     assert isinstance(data["data"]["heatingAggregated"][0]["co2e"], float)
     assert isinstance(data["data"]["heatingAggregated"][0]["co2eCap"], float)
     assert len(data["data"]["heatingAggregated"]) == 1
-
+    assert data["data"]["heatingAggregated"][0]["co2eCap"] == data["data"]["heatingAggregated"][0]["co2e"]
 
 def test_query_heating_aggregated_no_workinggroup(test_user1_token):
     """Query aggregated heating data by authenticated user"""

--- a/backend/src/emissions/tests/test_query_data.py
+++ b/backend/src/emissions/tests/test_query_data.py
@@ -72,6 +72,29 @@ def test_query_heating_aggregated_personal(test_user3_rep_token):
     assert len(data["data"]["heatingAggregated"]) == 1
 
 
+def test_query_heating_aggregated_no_workinggroup(test_user1_token):
+    """Query aggregated heating data by authenticated user"""
+    query = """
+        query ($level: String!) {
+          heatingAggregated (level: $level) {
+            date
+            co2e
+            co2eCap
+          }
+    }
+    """
+    variables = {"level": "personal"}
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"JWT {test_user1_token}",
+    }
+    response = requests.post(
+        GRAPHQL_URL, json={"query": query, "variables": variables}, headers=headers
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["errors"][0]["message"] == 'No heating data available, since user is not assigned to any working group yet.'
+
 
 def test_query_electricity_aggregated_institution(test_user3_rep_token):
     """Query aggregated electricity data by authenticated user"""

--- a/backend/src/emissions/tests/test_query_data.py
+++ b/backend/src/emissions/tests/test_query_data.py
@@ -123,6 +123,35 @@ def test_query_electricity_aggregated_institution(test_user3_rep_token):
     assert len(data["data"]["electricityAggregated"]) == 1
 
 
+
+def test_query_electricity_aggregated_institution(test_user3_rep_token):
+    """Query aggregated electricity data by authenticated user"""
+    query = """
+        query ($level: String!) {
+          electricityAggregated (level: $level) {
+            date
+            co2e
+            co2eCap
+          }
+    }
+    """
+    variables = {"level": "institution"}
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"JWT {test_user3_rep_token}",
+    }
+    response = requests.post(
+        GRAPHQL_URL, json={"query": query, "variables": variables}, headers=headers
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data["data"]["electricityAggregated"][0]["date"], str)
+    assert isinstance(data["data"]["electricityAggregated"][0]["co2e"], float)
+    assert isinstance(data["data"]["electricityAggregated"][0]["co2eCap"], float)
+    assert len(data["data"]["electricityAggregated"]) == 1
+
+
+
 def test_query_businesstrip_aggregated_personal(test_user1_token):
     """Query aggregated businesstrip data by authenticated user"""
     query = """

--- a/backend/src/emissions/tests/test_query_data.py
+++ b/backend/src/emissions/tests/test_query_data.py
@@ -42,6 +42,35 @@ def test_query_heating_aggregated(test_user3_rep_token):
     assert isinstance(data["data"]["heatingAggregated"][0]["date"], str)
     assert isinstance(data["data"]["heatingAggregated"][0]["co2e"], float)
     assert isinstance(data["data"]["heatingAggregated"][0]["co2eCap"], float)
+    assert len(data["data"]["heatingAggregated"]) == 1
+
+
+def test_query_heating_aggregated_personal(test_user3_rep_token):
+    """Query aggregated heating data by authenticated user"""
+    query = """
+        query ($level: String!) {
+          heatingAggregated (level: $level) {
+            date
+            co2e
+            co2eCap
+          }
+    }
+    """
+    variables = {"level": "personal"}
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"JWT {test_user3_rep_token}",
+    }
+    response = requests.post(
+        GRAPHQL_URL, json={"query": query, "variables": variables}, headers=headers
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data["data"]["heatingAggregated"][0]["date"], str)
+    assert isinstance(data["data"]["heatingAggregated"][0]["co2e"], float)
+    assert isinstance(data["data"]["heatingAggregated"][0]["co2eCap"], float)
+    assert len(data["data"]["heatingAggregated"]) == 1
+
 
 
 def test_query_electricity_aggregated_institution(test_user3_rep_token):
@@ -68,6 +97,7 @@ def test_query_electricity_aggregated_institution(test_user3_rep_token):
     assert isinstance(data["data"]["electricityAggregated"][0]["date"], str)
     assert isinstance(data["data"]["electricityAggregated"][0]["co2e"], float)
     assert isinstance(data["data"]["electricityAggregated"][0]["co2eCap"], float)
+    assert len(data["data"]["electricityAggregated"]) == 1
 
 
 def test_query_businesstrip_aggregated_personal(test_user1_token):

--- a/clean.sh
+++ b/clean.sh
@@ -1,5 +1,11 @@
-docker compose down
-docker volume rm wepledge_backend_env wepledge_backend_extensions wepledge_db-data wepledge_frontend_extensions wepledge_frontend_nodemodules
-docker image rm wepledge-backend wepledge-frontend
+PROJECT=${1:-wepledge}
+echo "Deleting containers and networks..."
+docker compose -p $PROJECT down
+echo "Deleting volumes..."
+echo ${PROJECT}_backend_env
+docker volume rm ${PROJECT}_backend_env ${PROJECT}_backend_extensions ${PROJECT}_db_data ${PROJECT}_frontend_extensions ${PROJECT}_frontend_nodemodules
+echo "Deleting images..."
+docker image rm $PROJECT-backend $PROJECT-frontend
+echo "Deleting django migrations in ./backend/src/emissions/migrations ..."
 rm -Rf ./backend/src/emissions/migrations/0*.py
 rm -Rf ./**/**/__pycache__/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: postgres
     restart: always
     volumes:
-      - db-data:/var/lib/postgresql/data
+      - db_data:/var/lib/postgresql/data
     environment:
       - POSTGRES_DB=postgres
       - POSTGRES_USER=postgres
@@ -46,4 +46,4 @@ volumes:
   frontend_extensions:
   backend_env:
   backend_extensions:
-  db-data:
+  db_data:


### PR DESCRIPTION
- added `level=personal` as option to HeatingAggregated and ElectricityAggregated endpoints. Since these emissions are only collected on a working group level, the value for `co2e_cap` (co2e emissions per person) is returned as `co2e` ( absolute co2e emissions). Closes #237 
- Added tests and test data for querying `HeatingAggregated` and `ElectricityAggregated` endpoints 
- Improve `./clean.sh` to delete all images, containers, networks and volumes for a clean rebuild
 